### PR TITLE
Increase bpool size to 2G so we don't risk boot breaking

### DIFF
--- a/hetzner-debian10-zfs-setup.sh
+++ b/hetzner-debian10-zfs-setup.sh
@@ -514,7 +514,7 @@ echo "======= partitioning the disk =========="
   for selected_disk in "${v_selected_disks[@]}"; do
     wipefs --all --force "$selected_disk"
     sgdisk -a1 -n1:24K:+1000K            -t1:EF02 "$selected_disk"
-    sgdisk -n2:0:+512M                   -t2:BF01 "$selected_disk" # Boot pool
+    sgdisk -n2:0:+2G                   -t2:BF01 "$selected_disk" # Boot pool
     sgdisk -n3:0:"$tail_space_parameter" -t3:BF01 "$selected_disk" # Root pool
   done
 

--- a/hetzner-debian11-zfs-setup.sh
+++ b/hetzner-debian11-zfs-setup.sh
@@ -515,7 +515,7 @@ echo "======= partitioning the disk =========="
   for selected_disk in "${v_selected_disks[@]}"; do
     wipefs --all --force "$selected_disk"
     sgdisk -a1 -n1:24K:+1000K            -t1:EF02 "$selected_disk"
-    sgdisk -n2:0:+512M                   -t2:BF01 "$selected_disk" # Boot pool
+    sgdisk -n2:0:+2G                   -t2:BF01 "$selected_disk" # Boot pool
     sgdisk -n3:0:"$tail_space_parameter" -t3:BF01 "$selected_disk" # Root pool
   done
 

--- a/hetzner-ubuntu18-zfs-setup.sh
+++ b/hetzner-ubuntu18-zfs-setup.sh
@@ -482,7 +482,7 @@ echo "======= partitioning the disk =========="
   for selected_disk in "${v_selected_disks[@]}"; do
     wipefs --all --force "$selected_disk"
     sgdisk -a1 -n1:24K:+1000K            -t1:EF02 "$selected_disk"
-    sgdisk -n2:0:+512M                   -t2:BF01 "$selected_disk" # Boot pool
+    sgdisk -n2:0:+2G                   -t2:BF01 "$selected_disk" # Boot pool
     sgdisk -n3:0:"$tail_space_parameter" -t3:BF01 "$selected_disk" # Root pool
   done
 

--- a/hetzner-ubuntu20-zfs-setup.sh
+++ b/hetzner-ubuntu20-zfs-setup.sh
@@ -482,7 +482,7 @@ echo "======= partitioning the disk =========="
   for selected_disk in "${v_selected_disks[@]}"; do
     wipefs --all --force "$selected_disk"
     sgdisk -a1 -n1:24K:+1000K            -t1:EF02 "$selected_disk"
-    sgdisk -n2:0:+512M                   -t2:BF01 "$selected_disk" # Boot pool
+    sgdisk -n2:0:+2G                   -t2:BF01 "$selected_disk" # Boot pool
     sgdisk -n3:0:"$tail_space_parameter" -t3:BF01 "$selected_disk" # Root pool
   done
 


### PR DESCRIPTION
512MB is too small to fit 4 kernels, which is what a Debian/Ubuntu system will have if apt pulls updates for both ZFS and kernel at the same time. Should fix https://github.com/terem42/zfs-hetzner-vm/issues/29