### PR TITLE
Start systemd-resolved to enable correct DNS resolution

### DIFF
--- a/hetzner-debian10-zfs-setup.sh
+++ b/hetzner-debian10-zfs-setup.sh
@@ -631,6 +631,7 @@ Address=${ip6addr_prefix}:1/64
 Gateway=fe80::1
 CONF
 chroot_execute "systemctl enable systemd-networkd.service"
+chroot_execute "systemctl enable systemd-resolved.service"
 
 
 cp /etc/resolv.conf $c_zfs_mount_dir/etc/resolv.conf

--- a/hetzner-debian11-zfs-setup.sh
+++ b/hetzner-debian11-zfs-setup.sh
@@ -632,6 +632,7 @@ Address=${ip6addr_prefix}:1/64
 Gateway=fe80::1
 CONF
 chroot_execute "systemctl enable systemd-networkd.service"
+chroot_execute "systemctl enable systemd-resolved.service"
 
 
 cp /etc/resolv.conf $c_zfs_mount_dir/etc/resolv.conf

--- a/hetzner-ubuntu18-zfs-setup.sh
+++ b/hetzner-ubuntu18-zfs-setup.sh
@@ -600,6 +600,7 @@ Gateway=fe80::1
 CONF
 
 chroot_execute "systemctl enable systemd-networkd.service"
+chroot_execute "systemctl enable systemd-resolved.service"
 
 
 mkdir -p "$c_zfs_mount_dir/etc/cloud/cloud.cfg.d/"

--- a/hetzner-ubuntu20-zfs-setup.sh
+++ b/hetzner-ubuntu20-zfs-setup.sh
@@ -600,6 +600,7 @@ Gateway=fe80::1
 CONF
 
 chroot_execute "systemctl enable systemd-networkd.service"
+chroot_execute "systemctl enable systemd-resolved.service"
 
 
 mkdir -p "$c_zfs_mount_dir/etc/cloud/cloud.cfg.d/"


### PR DESCRIPTION
After setting up the servers, DNS resolution is not running. The `resolv.conf` file points at the DNS resolver 127.0.0.53 which is the default for the systemd resolved service.

Once this service has been started, DNS resolution works as intended.