### PR TITLE
ubuntu20: update dropbear URL's

### DIFF
--- a/hetzner-ubuntu20-zfs-setup.sh
+++ b/hetzner-ubuntu20-zfs-setup.sh
@@ -767,13 +767,13 @@ if [[ $v_encrypt_rpool == "1" ]]; then
   rm -rf "$c_zfs_mount_dir/etc/dropbear-initramfs/dropbear_dss_host_key"
 
   cd "$c_zfs_mount_dir/root"
-  wget http://ftp.de.debian.org/debian/pool/main/libt/libtommath/libtommath1_1.1.0-3_amd64.deb
-  wget http://ftp.de.debian.org/debian/pool/main/d/dropbear/dropbear-bin_2018.76-5_amd64.deb
-  wget http://ftp.de.debian.org/debian/pool/main/d/dropbear/dropbear-initramfs_2018.76-5_all.deb
+  wget http://ftp.de.debian.org/debian/pool/main/libt/libtommath/libtommath1_1.2.0-6_amd64.deb
+  wget http://ftp.de.debian.org/debian/pool/main/d/dropbear/dropbear-bin_2020.81-3_amd64.deb
+  wget http://ftp.de.debian.org/debian/pool/main/d/dropbear/dropbear-initramfs_2020.81-3_all.deb
 
-  chroot_execute "dpkg -i /root/libtommath1_1.1.0-3_amd64.deb"
-  chroot_execute "dpkg -i /root/dropbear-bin_2018.76-5_amd64.deb"
-  chroot_execute "dpkg -i /root/dropbear-initramfs_2018.76-5_all.deb"
+  chroot_execute "dpkg -i /root/libtommath1_1.2.0-6_amd64.deb"
+  chroot_execute "dpkg -i /root/dropbear-bin_2020.81-3_amd64.deb"
+  chroot_execute "dpkg -i /root/dropbear-initramfs_2020.81-3_all.deb"
 
   rm $c_zfs_mount_dir/root/*.deb
   cd /root


### PR DESCRIPTION
From Debian, old links were dead
These are slightly newer and not dead.

Makes install script work again.