### PR TITLE
ubuntu20: install zfs from bullseye-backports (on recovery)

### DIFF
--- a/hetzner-ubuntu20-zfs-setup.sh
+++ b/hetzner-ubuntu20-zfs-setup.sh
@@ -461,13 +461,8 @@ done
 
 echo "======= installing zfs on rescue system =========="
   echo "zfs-dkms zfs-dkms/note-incompatible-licenses note true" | debconf-set-selections
-  apt-get install --yes software-properties-common
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8CF63AD3F06FC659
-  add-apt-repository 'deb http://ppa.launchpad.net/jonathonf/zfs/ubuntu focal main'
   apt update
-  apt install --yes zfs-dkms zfsutils-linux
-  add-apt-repository -r 'deb http://ppa.launchpad.net/jonathonf/zfs/ubuntu focal main'
-  apt update
+  apt install -t bullseye-backports --yes zfs-dkms zfsutils-linux
   find /usr/local/sbin/ -type l -exec rm {} +
   zfs --version
 


### PR DESCRIPTION
Hetzner's current recovery uses debian, Ubuntu PPA packages don't work. This simplifies things.