### PR TITLE
Use grub2 compatibility

### DIFF
--- a/hetzner-debian12-zfs-setup.sh
+++ b/hetzner-debian12-zfs-setup.sh
@@ -555,6 +555,7 @@ echo "======= create zfs pools and datasets =========="
 zpool create \
   $v_bpool_tweaks -O canmount=off -O devices=off \
   -o cachefile=/etc/zpool.cache \
+  -o compatibility=grub2 \
   -O mountpoint=/boot -R $c_zfs_mount_dir -f \
   $v_bpool_name $pools_mirror_option "${bpool_disks_partitions[@]}"
 


### PR DESCRIPTION
In order to get grub to recognize `bpool` (and not complain with `grub-install: error: unknown filesystem.` ), I needed this option (zfs 2.2).