### PR TITLE
Update hetzner-debian12-zfs-setup.sh

### DIFF
--- a/hetzner-debian12-zfs-setup.sh
+++ b/hetzner-debian12-zfs-setup.sh
@@ -563,6 +563,7 @@ echo "======= create zfs pools and datasets =========="
 
 # shellcheck disable=SC2086
 zpool create \
+  -m none \
   -o cachefile=/etc/zpool.cache \
   -o compatibility=grub2 \
   -O mountpoint=/boot -R $c_zfs_mount_dir -f \
@@ -570,6 +571,7 @@ zpool create \
 
 # shellcheck disable=SC2086
 echo -n "$v_passphrase" | zpool create \
+  -m none \
   $v_rpool_tweaks \
   -o cachefile=/etc/zpool.cache \
   "${encryption_options[@]}" \


### PR DESCRIPTION
fix for 
===========remove unused kernels in rescue system========= Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package linux-headers-6.11.3
E: Couldn't find any package by glob 'linux-headers-6.11.3'