### PR TITLE
add support for virtio device and use more robust part uuid to create zfs pool

### DIFF
--- a/hetzner-debian12-zfs-setup.sh
+++ b/hetzner-debian12-zfs-setup.sh
@@ -38,7 +38,16 @@ v_zfs_experimental=
 v_suitable_disks=()
 
 # Constants
-c_default_zfs_arc_max_mb=250
+c_default_zfs_arc_max_mb=$(
+  total_mem_mb=$(free -m | awk 'NR==2{print $2}' 2>/dev/null || echo 1024)
+  if [[ $total_mem_mb -le 1024 ]]; then
+    echo 256
+  elif [[ $total_mem_mb -le 2048 ]]; then
+    echo 512
+  else
+    echo $((total_mem_mb / 4))
+  fi
+)
 c_default_bpool_tweaks="-o ashift=12 -O compression=lz4"
 c_default_rpool_tweaks="-o ashift=12 -O acltype=posixacl -O compression=zstd-9 -O dnodesize=auto -O relatime=on -O xattr=sa -O normalization=formD"
 c_default_hostname=terem

--- a/hetzner-debian12-zfs-setup.sh
+++ b/hetzner-debian12-zfs-setup.sh
@@ -59,6 +59,13 @@ c_disks_log=$c_log_dir/disks.log
 c_efimode_enabled="$(if [[ -d /sys/firmware/efi/efivars ]]; then echo 1; else echo 0; fi)"
 
 # --begin-- debian distribution related functions
+# Constants (can be overridden by environment variables)
+# Debian version - change this to upgrade to a different version (e.g., trixie for Debian 13)
+c_debian_version=${DEBIAN_VERSION:-bookworm}
+# Mirror repositories - can use 163 mirror: http://mirrors.163.com/debian
+c_deb_packages_repo=${DEB_PACKAGES_REPO:-https://deb.debian.org/debian}
+c_deb_security_repo=${DEB_SECURITY_REPO:-https://deb.debian.org/debian-security}
+
 ## --begin-- 1. host part
 function setup_host_apt_sources {
   # Ensure rescue system has non-free sources for ZFS installation
@@ -66,10 +73,10 @@ function setup_host_apt_sources {
   
   if host_codename=$(lsb_release -cs 2>/dev/null); then
     cat > "/etc/apt/sources.list" <<CONF
-deb https://deb.debian.org/debian $host_codename main contrib non-free non-free-firmware
-deb https://deb.debian.org/debian $host_codename-backports main contrib non-free non-free-firmware
-deb https://deb.debian.org/debian $host_codename-updates main contrib non-free non-free-firmware
-deb https://deb.debian.org/debian-security $host_codename-security main contrib non-free non-free-firmware
+deb $c_deb_packages_repo $host_codename main contrib non-free non-free-firmware
+deb $c_deb_packages_repo $host_codename-backports main contrib non-free non-free-firmware
+deb $c_deb_packages_repo $host_codename-updates main contrib non-free non-free-firmware
+deb $c_deb_security_repo $host_codename-security main contrib non-free non-free-firmware
 CONF
     apt update
   else
@@ -101,11 +108,6 @@ function install_host_zfs {
 }
 ## --end-- 1. host part
 ## --begin-- 2. target part
-# Debian version - change this to upgrade to a different version
-c_debian_version=bookworm
-c_deb_packages_repo=https://deb.debian.org/debian
-c_deb_security_repo=https://deb.debian.org/debian-security
-
 function setup_apt_sources {
   # Configure APT sources for the target system
   # This function can be easily modified to support different Debian versions

--- a/hetzner-debian12-zfs-setup.sh
+++ b/hetzner-debian12-zfs-setup.sh
@@ -547,7 +547,7 @@ echo "======= create zfs pools and datasets =========="
   encryption_options=()
   rpool_disks_partitions=()
   bpool_disks_partitions=()
-  efi_partitions_uuid=()
+  efi_disks_partitions=()
 
   if [[ $v_encrypt_rpool == "1" ]]; then
     encryption_options=(-O "encryption=aes-256-gcm" -O "keylocation=prompt" -O "keyformat=passphrase")
@@ -568,7 +568,7 @@ echo "======= create zfs pools and datasets =========="
       bpool_disks_partitions+=("/dev/disk/by-partuuid/$bpool_partuuid")
     fi
     if [[ -n "$efi_partuuid" ]]; then
-      efi_partitions_uuid+=("$efi_partuuid")
+      efi_disks_partitions+=("$efi_partuuid")
     fi
   done
 
@@ -639,11 +639,11 @@ fi
 if (( c_efimode_enabled == 1 )); then
 echo "======= create filesystem on EFI partition(s) =========="
 
-  for efi_partuuid in "${efi_partitions_uuid[@]}"; do
+  for efi_partuuid in "${efi_disks_partitions[@]}"; do
     mkfs.fat -F32 "/dev/disk/by-partuuid/$efi_partuuid"
   done
   mkdir -p "$c_zfs_mount_dir/boot/efi"
-  mount "/dev/disk/by-partuuid/${efi_partitions_uuid[0]}" "$c_zfs_mount_dir/boot/efi"
+  mount "/dev/disk/by-partuuid/${efi_disks_partitions[0]}" "$c_zfs_mount_dir/boot/efi"
 fi
 
 echo "======= setting up initial system packages =========="
@@ -816,8 +816,8 @@ chroot_execute "sed -i 's/quiet//g' /etc/default/grub"
 chroot_execute "sed -i 's/splash//g' /etc/default/grub"
 chroot_execute "echo 'GRUB_DISABLE_OS_PROBER=true'   >> /etc/default/grub"
 
-for ((i = 1; i < ${#efi_partitions_uuid[@]}; i++)); do
-  dd if="/dev/disk/by-partuuid/${efi_partitions_uuid[0]}" of="/dev/disk/by-partuuid/${efi_partitions_uuid[i]}"
+for ((i = 1; i < ${#efi_disks_partitions[@]}; i++)); do
+  dd if="/dev/disk/by-partuuid/${efi_disks_partitions[0]}" of="/dev/disk/by-partuuid/${efi_disks_partitions[i]}"
 done
 
 if [[ $v_encrypt_rpool == "1" ]]; then


### PR DESCRIPTION
two improve:

1. add support for virtio device, which can not find by find /dev/disk/by-id
2. use part uuid but not xxx-disk{1,2,3} to create zfs pool, which is more robust